### PR TITLE
[bt#13749] Updating from latest remote 13.0 

### DIFF
--- a/hg_dhl/controllers/main.py
+++ b/hg_dhl/controllers/main.py
@@ -7,7 +7,8 @@ class Hg_Dhl_Link(http.Controller):
         Because external systems do not know the internal record id, we provide an automated redirection.
         The external link is .../hg_dhl/nnnnnnnnnnnnnnnn and n stand for the DHL tracking number
     """
-    @http.route('/hg_dhl/<track_no>', type='http', auth='user')
+    @http.route('/hg_dhl/<track_no>', website=True, type='http', auth='user')
+#    @http.route('/hg_dhl/<track_no>', type='http', auth='user')
     def hg_redirect(self, track_no, **kwargs):
         # get the record id
         hg_dhl_track = request.env['hg.tracking'].sudo().search([('tracking_no','=',track_no)])
@@ -17,10 +18,6 @@ class Hg_Dhl_Link(http.Controller):
             track_id = hg_dhl_track[0].id
         except Exception:
             return '<h1>Keine Tracking Daten gefunden!</h1>'
-        return_string = '<head>'\
-                        '<meta http-equiv = "refresh" content = "1; URL='\
-                        '/web#id={track_id}'\
-                        '&action=512&model=hg.tracking&view_type=form&cids=&menu_id=355">'\
-                        '</head>'\
-                        '<body><strong>Tracking Daten werden geladen ... </strong></body>'
-        return return_string.format(track_id=track_id)
+        #finally we redirect to the tracking form with track_id
+        url_string = '/web#id={track_id}&model=hg.tracking&view_type=form'
+        return request.redirect(url_string.format(track_id=track_id))

--- a/hg_dhl/reports/report.xml
+++ b/hg_dhl/reports/report.xml
@@ -128,7 +128,7 @@
 
 
     <report
-            id="report_hg_tracking"
+            id="action_report_hg_tracking"
             string="DHL Tracking Details"
             model="hg.tracking"
             report_type="qweb-pdf"


### PR DESCRIPTION
- improved controller to launch tracking number
- duplicate names in report.xml removed

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=13749">[bt#13749] Update MIDE Test</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>hg_dhl</td><td>.py, .xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->